### PR TITLE
Add automatic release build workflow, triggered by pushing new tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}/kernel
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      
+      - name: Dependencies
+        run: bash ./setup.sh
+
+      - name: Build kernel
+        run: bash ./build.sh
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: "${{ github.workspace }}/kernel/build/my_console.uf2"
+
+      - name: Upload artifact
+        uses: softprops/action-gh-release@v2
+        if: github.ref_type == 'tag'
+        with:
+          files: "${{ github.workspace }}/kernel/build/my_console.uf2"
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated release process: Implemented automated release creation and artifact upload. When version tags are pushed, the system automatically builds, generates release notes, and uploads artifacts for distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->