### PR TITLE
Cache the Pico SDK between runs (unless the CMakeLists.txt changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Cache Pico SDK
+        id: cache-sdk
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/kernel/pico-sdk
+          key: pico-sdk-${{ runner.os }}-${{ hashFiles('kernel/CMakeLists.txt') }}
       
       - name: Dependencies
         run: bash ./setup.sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build caching in the release workflow to improve build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->