### PR TITLE
Add Visual Studio 2022 Build Tools to Windows deps and don't skip Git…

### DIFF
--- a/kernel/README.md
+++ b/kernel/README.md
@@ -31,6 +31,7 @@ On Windows systems you will need:
  - `GnuArmEmbeddedToolchain`
  - `Ninja`
  - `CMake`
+ - `Visual Studio 2022 Build Tools`
  - `Python3`
  - `Git`
 

--- a/kernel/setup.ps1
+++ b/kernel/setup.ps1
@@ -1,26 +1,21 @@
 Write-Host "--- INSTALLING PICO DEVELOPMENT TOOLS ---" -ForegroundColor Cyan
 
-if (Get-Command git -ErrorAction SilentlyContinue) {
-	Write-Host "Git installed, skipping..."
-} else {
-	Write-Host "Installing Git..."
-	winget install --id Git.Git -e --source winget
-}
+Write-Host "Installing Git..." -ForegroundColor Cyan
+winget install --id Git.Git -e --source winget
 
-if (Get-Command python -ErrorAction SilentlyContinue) {
-	Write-Host "Python installed, skipping..."
-} else {
-	Write-Host "Installing Python..."
-	winget install --moniker python3 -e --source winget
-}
+Write-Host "Installing Python..." -ForegroundColor Cyan
+winget install --moniker python3 -e --source winget
 
-Write-Host "Installing Arm GNU Toolchain..."
+Write-Host "Installing Visual Studio 2022 Build tools" -ForegroundColor Cyan
+winget install --id Microsoft.VisualStudio.2022.BuildTools --override "--passive --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+
+Write-Host "Installing Arm GNU Toolchain..." -ForegroundColor Cyan
 winget install --id Arm.GnuArmEmbeddedToolchain -e --source winget
 
-Write-Host "Installing Ninja..."
+Write-Host "Installing Ninja..." -ForegroundColor Cyan
 winget install --id Ninja-build.Ninja -e --source winget
 
-Write-Host "Installing CMake..."
+Write-Host "Installing CMake..." -ForegroundColor Cyan
 winget install --id Kitware.CMake -e --source winget
 
 Write-Host "Installation complete!" -ForegroundColor Green


### PR DESCRIPTION
… if found (it will just update) or Python

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Visual Studio 2022 Build Tools to Windows setup requirements.

* **Chores**
  * Improved setup script with streamlined installation steps and enhanced status messaging. Added reminders to restart terminal and IDE after completion for newly installed tools to be properly recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->